### PR TITLE
WDP220401-4

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -47,9 +47,7 @@ const ProductBox = ({ name, price, promo, stars }) => (
         </Button>
       </div>
       <div className={styles.price}>
-        <Button noHover variant='small'>
-          $ {price}
-        </Button>
+        <Button variant='small'>$ {price}</Button>
       </div>
     </div>
   </div>

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -31,6 +31,9 @@
     .buttons {
       display: flex;
       justify-content: space-between;
+      opacity: 0;
+      transition-property: opacity;
+      transition-duration: 1s;
     }
   }
 
@@ -74,5 +77,9 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  &:hover .buttons {
+    opacity: 1;
   }
 }

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -79,7 +79,12 @@
     align-items: center;
   }
 
-  &:hover .buttons {
-    opacity: 1;
+  &:hover {
+    .buttons {
+      opacity: 1;
+    }
+    .price a {
+      background-color: $primary;
+    }
   }
 }


### PR DESCRIPTION
**After**: Buttony "Quick view" oraz "Add to cart" zawsze widoczne,  nie zmienia się tło ceny przy najechaniu kursorem na boks z produktem.

**Before**: Przy najechaniu kursorem na boks z produktem stają widoczne buttony "Quick view" oraz "Add to cart", button z ceną zmienia kolor tła na `$primary` (jak w dizajnie projektu).
