### PR TITLE
WDP220401-17

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -68,7 +68,7 @@ class NewFurniture extends React.Component {
           </div>
           <div className='row'>
             {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col-3'>
+              <div key={item.id} className='col-lg-3 col-md-4 col-sm-6 col-12'>
                 <ProductBox {...item} />
               </div>
             ))}


### PR DESCRIPTION
**After**: W sekcji `New furniture` zawsze 4 produkty w rzędzie, nie zależnie od urządzenia.
**Before**: desktop - 4 produkty w rezedzie, tablet - 3 lub 2 produkty w rezedzie, mobile - 1 produkt w rzędzie