### PR TITLE
Fix FeatureBox responsive styles

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -4,6 +4,7 @@
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+  height: 90%;
 
   .iconWrapper {
     height: 60px;
@@ -75,5 +76,11 @@
     .content {
       color: $primary;
     }
+  }
+}
+
+@media (min-width: 992px) {
+  .root {
+    height: 100%;
   }
 }

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -15,25 +15,25 @@ const FeatureBoxes = () => (
   <div className={styles.root}>
     <div className='container'>
       <div className='row'>
-        <div className='col'>
+        <div className={'col-6 col-lg-3 ' + styles.featureBoxCol}>
           <FeatureBox icon={faTruck} active>
             <h5>Free shipping</h5>
             <p>All orders</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className={'col-6 col-lg-3 ' + styles.featureBoxCol}>
           <FeatureBox icon={faHeadphones}>
             <h5>24/7 customer</h5>
             <p>support</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className={'col-6 col-lg-3 ' + styles.featureBoxCol}>
           <FeatureBox icon={faReplyAll}>
             <h5>Money back</h5>
             <p>guarantee</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className={'col-6 col-lg-3 ' + styles.featureBoxCol}>
           <FeatureBox icon={faBullhorn}>
             <h5>Member discount</h5>
             <p>First order</p>

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -1,8 +1,20 @@
 @import "../../../styles/settings.scss";
 
 .root {
-  padding: 5rem 0;
+  padding: 2.5rem 0;
   a {
     text-decoration: none;
+  }
+  .featureBoxCol {
+    margin-bottom: 40px;
+  }
+}
+
+@media (min-width: 992px) {
+  .root {
+    padding: 5rem 0;
+    .featureBoxCol {
+      margin-bottom: 0px;
+    }
   }
 }


### PR DESCRIPTION
https://projects.kodilla.com/browse/WDP220401-16

**OPIS PROBLEMU**

- Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
- Ten task dotyczy kart korzyści ("Free shipping", etc.).
- Klient chce w trybach tablet i mobile mieć je w 2 rzędach, po 2 elementy w każdym, ale elementy w jednym rzędzie (obok siebie) nie powinny się różnić wysokością. 

**OPIS ROZWIAZANIA**

- poprawiłem przy pomocy styli bootstrap zwijanie elementów FeatureBoxes, dodałem na kolumnach style: "col-6 col-lg-3"
- nadałem dla FeatureBox wysokość 100% i przy wersji mobilnej 90% - aby elementy w rzędzie miały taką samą wysokość
- poprawiłem również lekko padding dla elementu FeatureBoxes dla wersji mobile i tablet
